### PR TITLE
L-156: Basic support for API rate limits

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -17,7 +17,7 @@ def ratelimit(f):
 
         if resp.status_code == 429 and self.ratelimit:
             retry_after = resp.headers.get(CLIO_API_RETRY_AFTER)
-            logging.info(f"Sleeping for {retry_after}s")
+            logging.info(f"Clio Rate Limit hit, Retry-After: {retry_after}s")
             time.sleep(int(retry_after))
 
             # Retry the request

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -10,7 +10,7 @@ CLIO_API_RATELIMIT_REMAINING_HEADER = "X-RateLimit-Remaining"
 CLIO_API_RETRY_AFTER = "Retry-After"
 
 
-def __ratelimit(f):
+def ratelimit(f):
     def wrapper(self, *args):
         print("__ratelimit")
         print(self.ratelimit, self.ratelimit_limit, self.ratelimit_remaining)
@@ -62,17 +62,17 @@ class Session:
                 CLIO_API_RATELIMIT_REMAINING_HEADER
             )
 
-    @__ratelimit
+    @ratelimit
     def __get_resource(self, url, **kwargs):
         resp = self.session.get(url, params=kwargs)
         return resp.json()
 
-    @__ratelimit
+    @ratelimit
     def __post_resource(self, url, json, **kwargs):
         resp = self.session.post(url, json=json, **kwargs)
         return resp.json()
 
-    @__ratelimit
+    @ratelimit
     def __patch_resource(self, url, json, **kwargs):
         resp = self.session.patch(url, json=json, **kwargs)
         return resp.json()
@@ -95,7 +95,6 @@ class Session:
             else:
                 # no paging meta, break the loop
                 next_url = None
-
 
     def get_contact(self, id, **kwargs):
         """GET a Contact."""

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -17,7 +17,7 @@ def __ratelimit(f):
 
         resp = f(self, *args)
 
-        if resp.status == 429:
+        if resp.status == 429 and self.ratelimit:
             retry_after = resp.headers.get(CLIO_API_RETRY_AFTER)
             print(f"Sleeping for {retry_after}s")
             time.sleep(retry_after)

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -20,7 +20,7 @@ def ratelimit(f):
         if resp.status_code == 429 and self.ratelimit:
             retry_after = resp.headers.get(CLIO_API_RETRY_AFTER)
             print(f"Sleeping for {retry_after}s")
-            time.sleep(retry_after)
+            time.sleep(int(retry_after))
 
             # Retry the request
             resp = f(self, *args)

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -25,7 +25,7 @@ def ratelimit(f):
             # Retry the request
             resp = f(self, *args)
 
-        self.__update_ratelimits(resp)
+        self.update_ratelimits(resp)
         return resp.json()
     return wrapper
 
@@ -53,7 +53,7 @@ class Session:
     def __make_url(path):
         return f"{CLIO_API_BASE_URL_US}/{path}.json"
 
-    def __update_ratelimits(self, response):
+    def update_ratelimits(self, response):
         if self.ratelimit:
             self.ratelimit_limit = response.headers.get(
                 CLIO_API_RATELIMIT_LIMIT_HEADER

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -26,7 +26,7 @@ def ratelimit(f):
             resp = f(self, *args)
 
         self.__update_ratelimits(resp)
-        return resp
+        return resp.json()
     return wrapper
 
 
@@ -64,18 +64,15 @@ class Session:
 
     @ratelimit
     def __get_resource(self, url, **kwargs):
-        resp = self.session.get(url, params=kwargs)
-        return resp.json()
+        return self.session.get(url, params=kwargs)
 
     @ratelimit
     def __post_resource(self, url, json, **kwargs):
-        resp = self.session.post(url, json=json, **kwargs)
-        return resp.json()
+        return self.session.post(url, json=json, **kwargs)
 
     @ratelimit
     def __patch_resource(self, url, json, **kwargs):
-        resp = self.session.patch(url, json=json, **kwargs)
-        return resp.json()
+        return self.session.patch(url, json=json, **kwargs)
 
     def __get_paginated_resource(self, url, **kwargs):
         next_url = url

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import math
 import requests
 import time
@@ -12,14 +13,11 @@ CLIO_API_RETRY_AFTER = "Retry-After"
 
 def ratelimit(f):
     def wrapper(self, *args):
-        print("__ratelimit")
-        print(self.ratelimit, self.ratelimit_limit, self.ratelimit_remaining)
-
         resp = f(self, *args)
 
         if resp.status_code == 429 and self.ratelimit:
             retry_after = resp.headers.get(CLIO_API_RETRY_AFTER)
-            print(f"Sleeping for {retry_after}s")
+            logging.info(f"Sleeping for {retry_after}s")
             time.sleep(int(retry_after))
 
             # Retry the request

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -17,7 +17,7 @@ def ratelimit(f):
 
         resp = f(self, *args)
 
-        if resp.status == 429 and self.ratelimit:
+        if resp.status_code == 429 and self.ratelimit:
             retry_after = resp.headers.get(CLIO_API_RETRY_AFTER)
             print(f"Sleeping for {retry_after}s")
             time.sleep(retry_after)


### PR DESCRIPTION
Adds `ratelimit` optional parameter to `hyacinth.Session`, defaulted to `False`. Setting `ratelimit` to `True` will cause all of the Session's HTTP requests to be rate limited according to Clio's rate limit scheme.

Usage:
```python
s = hyacinth.Session(client_id=clio_client_id,
                     client_secret=clio_client_secret,
                     token=token,
                     ratelimit=True)
```
```python
for i in range(0, 100):
    print(s.get_who_am_i())
```
```python
{'data': {'id': 350963386, 'etag': '"14eb46ba60ce9c2e6a68f6d0d2c36334"', 'name': 'Anson MacKeracher'}}
{'data': {'id': 350963386, 'etag': '"14eb46ba60ce9c2e6a68f6d0d2c36334"', 'name': 'Anson MacKeracher'}}
...
Sleeping for 56s
{'data': {'id': 350963386, 'etag': '"14eb46ba60ce9c2e6a68f6d0d2c36334"', 'name': 'Anson MacKeracher'}}
...
```