### PR TITLE
L-313: Error handling

### DIFF
--- a/hyacinth/__init__.py
+++ b/hyacinth/__init__.py
@@ -1,1 +1,1 @@
-from session import Session
+from .session import Session

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -24,6 +24,9 @@ def ratelimit(f):
             # Retry the request
             resp = f(self, *args, **kwargs)
 
+        elif self.raise_for_status:
+            resp.raise_for_status()
+
         self.update_ratelimits(resp)
         return resp.json()
     return wrapper
@@ -65,24 +68,15 @@ class Session:
 
     @ratelimit
     def __get_resource(self, url, **kwargs):
-        r = self.session.get(url, params=kwargs)
-        if self.raise_for_status:
-            r.raise_for_status()
-        return r
+        return self.session.get(url, params=kwargs)
 
     @ratelimit
     def __post_resource(self, url, json, **kwargs):
-        r = self.session.post(url, json=json, params=kwargs)
-        if self.raise_for_status:
-            r.raise_for_status()
-        return r
+        return self.session.post(url, json=json, params=kwargs)
 
     @ratelimit
     def __patch_resource(self, url, json, **kwargs):
-        r = self.session.patch(url, json=json, params=kwargs)
-        if self.raise_for_status:
-            r.raise_for_status()
-        return r
+        return self.session.patch(url, json=json, params=kwargs)
 
     def __get_paginated_resource(self, url, **kwargs):
         next_url = url

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -38,7 +38,8 @@ class Session:
 
     """
 
-    def __init__(self, token, client_id, client_secret, ratelimit=False):
+    def __init__(self, token, client_id, client_secret,
+                 ratelimit=False, raise_for_status=False):
         """Initialize Session with optional ratelimits."""
         self.session = OAuth2Session(client_id=client_id,
                                      client_secret=client_secret,
@@ -47,6 +48,7 @@ class Session:
         self.ratelimit = ratelimit
         self.ratelimit_limit = math.inf
         self.ratelimit_remaining = math.inf
+        self.raise_for_status = raise_for_status
 
     @staticmethod
     def __make_url(path):
@@ -63,15 +65,24 @@ class Session:
 
     @ratelimit
     def __get_resource(self, url, **kwargs):
-        return self.session.get(url, params=kwargs)
+        r = self.session.get(url, params=kwargs)
+        if self.raise_for_status:
+            r.raise_for_status()
+        return r
 
     @ratelimit
     def __post_resource(self, url, json, **kwargs):
-        return self.session.post(url, json=json, params=kwargs)
+        r = self.session.post(url, json=json, params=kwargs)
+        if self.raise_for_status:
+            r.raise_for_status()
+        return r
 
     @ratelimit
     def __patch_resource(self, url, json, **kwargs):
-        return self.session.patch(url, json=json, params=kwargs)
+        r = self.session.patch(url, json=json, params=kwargs)
+        if self.raise_for_status:
+            r.raise_for_status()
+        return r
 
     def __get_paginated_resource(self, url, **kwargs):
         next_url = url


### PR DESCRIPTION
Adds (optional) support for `requests` [`raise_for_status`](https://requests.readthedocs.io/en/latest/api/#requests.Response.raise_for_status), which will raise an exception for any non-200 HTTP `status_code`.

Usage:
```python
>> s = hyacinth.Session(token=<...>, client_id=<...>, client_secret=<...>, raise_for_status=True)
>> s.get_user(id="not_a_real_user")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/amackera/projects/hyacinth/hyacinth/session.py", line 124, in get_user
    return self.__get_resource(url, **kwargs)
  File "/Users/amackera/projects/hyacinth/hyacinth/session.py", line 17, in wrapper
    resp = f(self, *args, **kwargs)
  File "/Users/amackera/projects/hyacinth/hyacinth/session.py", line 70, in __get_resource
    r.raise_for_status()
  File "/Users/amackera/Library/Caches/pypoetry/virtualenvs/hyacinth-HokE19MQ-py3.10/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://app.clio.com/api/v4/users/not_a_real_user.json
```