### PR TITLE
L-572: Fix upload_document bug with params

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -220,7 +220,7 @@ class Session:
         post_url = Session.__make_url("documents")
         clio_document = self.__post_resource(
             post_url,
-            fields="id,latest_document_version{uuid,put_url,put_headers}",
+            params={"fields": "id,latest_document_version{uuid,put_url,put_headers}"},
             json={
                 "data": {"name": name, "parent": {"id": parent_id, "type": parent_type}}
             },
@@ -239,7 +239,7 @@ class Session:
         patch_url = self.__make_url(f"documents/{clio_document['data']['id']}")
         patch_resp = self.__patch_resource(
             patch_url,
-            fields="id,name,latest_document_version{fully_uploaded}",
+            params={"fields": "id,name,latest_document_version{fully_uploaded}"},
             json={
                 "data": {
                     "uuid": clio_document["data"]["latest_document_version"]["uuid"],


### PR DESCRIPTION
It was still using the old style of `fields=`.