### PR TITLE
L-662: Implement upload_document_async

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -279,7 +279,61 @@ class Session:
                 params={"fields": "id,name,latest_document_version{fully_uploaded}"},
                 json={
                     "data": {
-                        "uuid": clio_document["data"]["latest_document_version"]["uuid"],
+                        "uuid": clio_document["data"]["latest_document_version"][
+                            "uuid"
+                        ],
+                        "fully_uploaded": True,
+                    }
+                },
+            )
+
+            return patch_resp
+
+    async def upload_document_async(
+        self, name, parent_id, parent_type, document, progress_update=lambda *args: None
+    ):
+        """POST a new Document, PUT the data, and PATCH Document as fully_uploaded."""
+        with open(document, "rb") as f:
+            post_url = Session.__make_url("documents")
+            clio_document = self.__post_resource(
+                post_url,
+                params={
+                    "fields": "id,latest_document_version{uuid,put_url,put_headers}"
+                },
+                json={
+                    "data": {
+                        "name": name,
+                        "parent": {"id": parent_id, "type": parent_type},
+                    }
+                },
+            )
+
+            put_url = clio_document["data"]["latest_document_version"]["put_url"]
+            put_headers = clio_document["data"]["latest_document_version"][
+                "put_headers"
+            ]
+
+            headers_map = {}
+            for header in put_headers:
+                headers_map[header["name"]] = header["value"]
+
+            # We actually DON'T want to use the authenticated client here
+            async with aiohttp.ClientSession() as session:
+                response = await session.put(
+                    put_url, headers=headers_map, data=f, timeout=300
+                )
+                log.info(response)
+                progress_update()
+
+            patch_url = self.__make_url(f"documents/{clio_document['data']['id']}")
+            patch_resp = self.__patch_resource(
+                patch_url,
+                params={"fields": "id,name,latest_document_version{fully_uploaded}"},
+                json={
+                    "data": {
+                        "uuid": clio_document["data"]["latest_document_version"][
+                            "uuid"
+                        ],
                         "fully_uploaded": True,
                     }
                 },

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -288,7 +288,7 @@ class Session:
             return patch_resp
 
     async def upload_multipart_document(
-            self, name, parent_id, parent_type, document, progress_update
+        self, name, parent_id, parent_type, document, progress_update
     ):
         """Async fn to upload a new Document to Clio via the multipart upload feature."""
         with open(document, "rb") as f:
@@ -305,11 +305,13 @@ class Session:
 
         multiparts = []
         for idx, part in enumerate(parts, start=1):
-            multiparts.append({
-                "part_number": idx,
-                "content_length": len(part[2]),
-                # "content_md5": content_md5_str,
-            })
+            multiparts.append(
+                {
+                    "part_number": idx,
+                    "content_length": len(part[2]),
+                    # "content_md5": content_md5_str,
+                }
+            )
 
         post_url = Session.__make_url("documents")
 
@@ -337,7 +339,9 @@ class Session:
             part_number = part["part_number"]
             data_part = parts[part_number - 1][2]  # 'parts' is a list of tuples
             async with aiohttp.ClientSession() as session:
-                response = await session.put(put_url, headers=headers_map, data=data_part, timeout=300)
+                response = await session.put(
+                    put_url, headers=headers_map, data=data_part, timeout=300
+                )
                 log.info(response)
                 progress_update()
 

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -51,10 +51,10 @@ def ratelimit(f):
 class Session:
     """Session class for interacting with Clio Manage API.
 
-    WARNING: enabling `ratelimit` will block the process synchronously
-    when API rate limits are hit. Support for async hyacinth is coming
-    soon.
-:
+        WARNING: enabling `ratelimit` will block the process synchronously
+        when API rate limits are hit. Support for async hyacinth is coming
+        soon.
+    :
     """
 
     def __init__(
@@ -242,20 +242,29 @@ class Session:
         url = Session.__make_url(f"folders/{id}")
         return self.__delete_resource(url, **kwargs)
 
-    def upload_document(self, name, parent_id, parent_type, document, progress_update=lambda *args: None):
+    def upload_document(
+        self, name, parent_id, parent_type, document, progress_update=lambda *args: None
+    ):
         """POST a new Document, PUT the data, and PATCH Document as fully_uploaded."""
         with open(document, "rb") as f:
             post_url = Session.__make_url("documents")
             clio_document = self.__post_resource(
                 post_url,
-                params={"fields": "id,latest_document_version{uuid,put_url,put_headers}"},
+                params={
+                    "fields": "id,latest_document_version{uuid,put_url,put_headers}"
+                },
                 json={
-                    "data": {"name": name, "parent": {"id": parent_id, "type": parent_type}}
+                    "data": {
+                        "name": name,
+                        "parent": {"id": parent_id, "type": parent_type},
+                    }
                 },
             )
 
             put_url = clio_document["data"]["latest_document_version"]["put_url"]
-            put_headers = clio_document["data"]["latest_document_version"]["put_headers"]
+            put_headers = clio_document["data"]["latest_document_version"][
+                "put_headers"
+            ]
 
             headers_map = {}
             for header in put_headers:


### PR DESCRIPTION
Adds new `upload_document_async` async implementation of upload document to Clio.

(note: this adds async uploads to **normal** document uploads. Async mutlipart document uploads are already in place.