### PR TITLE
L-726: Increase PUT timeout for clio_async_session.upload_document

### DIFF
--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -123,7 +123,7 @@ class AsyncSession:
             # We don't want the authenticated session here, authn is
             # handled by the put_headers from Clio.
             async with aiohttp.ClientSession() as session:
-                await session.put(put_url, headers=headers_map, data=f, timeout=300)
+                await session.put(put_url, headers=headers_map, data=f, timeout=3600)
 
         patch_url = f"{CLIO_API_BASE_URL_US}/documents/{clio_document['data']['id']}"
         doc_params = {"fields": "id,name,latest_document_version{fully_uploaded}"}

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -271,7 +271,7 @@ class Session:
                 headers_map[header["name"]] = header["value"]
 
             # We actually DON'T want to use the authenticated client here
-            requests.put(put_url, headers=headers_map, data=f, timeout=5)
+            requests.put(put_url, headers=headers_map, data=f, timeout=600)
 
             patch_url = self.__make_url(f"documents/{clio_document['data']['id']}")
             patch_resp = self.__patch_resource(


### PR DESCRIPTION
This increases the HTTP PUT request timeout when uploading documents. Implements a 10 minute timeout for the synchronous client, and a 1 hour long timeout for the async client.