### PR TITLE
L-742: Add model specific fields to be returned in webhooks we create

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ target/
 .ipynb_checkpoints
 
 .envrc
+.vscode/

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -415,7 +415,7 @@ class Session:
     def post_webhook(self, url, model, events, params=None):
         """Post a Webhook to Clio."""
         post_url = Session.__make_url("webhooks")
-        webhook_params = {"fields": "id,shared_secret,status"}
+        webhook_params = {"fields": "id"}
         if params and params.get("fields"):
             webhook_params["fields"] = (
                 webhook_params["fields"] + "," + params.get("fields")

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -424,6 +424,8 @@ class Session:
         if params:
             webhook_params = webhook_params | params  # this merges the dicts
 
+        print(webhook_params)
+
         return self.__post_resource(
             post_url,
             json={

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -415,28 +415,18 @@ class Session:
     def post_webhook(self, url, model, events, params=None):
         """Post a Webhook to Clio."""
         post_url = Session.__make_url("webhooks")
-        webhook_params = {"fields": "id"}
-        if params and params.get("fields"):
-            webhook_params["fields"] = (
-                webhook_params["fields"] + "," + params.get("fields")
-            )
-            del params["fields"]
-        if params:
-            webhook_params = webhook_params | params  # this merges the dicts
-
-        print(webhook_params)
 
         return self.__post_resource(
             post_url,
             json={
                 "data": {
-                    "fields": "id",
+                    "fields": "id,custom_field_values",
                     "events": events,
                     "model": model,
                     "url": url,
                 },
             },
-            params=webhook_params,
+            params={"fields": "id,shared_secret,status"},
         )
 
     def get_document_templates(self, **kwargs):

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -412,9 +412,18 @@ class Session:
         )
         return patch_resp
 
-    def post_webhook(self, url, model, events):
+    def post_webhook(self, url, model, events, params=None):
         """Post a Webhook to Clio."""
         post_url = Session.__make_url("webhooks")
+        webhook_params = {"fields": "id,shared_secret,status"}
+        if params and params.get("fields"):
+            webhook_params["fields"] = (
+                webhook_params["fields"] + "," + params.get("fields")
+            )
+            del params["fields"]
+        if params:
+            webhook_params = webhook_params | params  # this merges the dicts
+
         return self.__post_resource(
             post_url,
             json={
@@ -425,7 +434,7 @@ class Session:
                     "url": url,
                 },
             },
-            params={"fields": "id,shared_secret,status"},
+            params=webhook_params,
         )
 
     def get_document_templates(self, **kwargs):

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -412,15 +412,17 @@ class Session:
         )
         return patch_resp
 
-    def post_webhook(self, url, model, events, params=None):
+    def post_webhook(self, url, model, events, fields=None):
         """Post a Webhook to Clio."""
         post_url = Session.__make_url("webhooks")
-
+        model_fields = "id"
+        if fields:
+            model_fields += "," + fields
         return self.__post_resource(
             post_url,
             json={
                 "data": {
-                    "fields": "id,custom_field_values",
+                    "fields": model_fields,
                     "events": events,
                     "model": model,
                     "url": url,


### PR DESCRIPTION
This PR adds the ability to include `fields="example_field"` to `post_webhook`. 