### PR TITLE
L-1015: DELETE Webhook

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -446,6 +446,11 @@ class Session:
             params={"fields": "id,shared_secret,status"},
         )
 
+    def delete_webhook(self, id, **kwargs):
+        """DELETE an existing Webhook with provided ID."""
+        url = Session.__make_url(f"webhooks/{id}")
+        return self.__delete_resource(url, **kwargs)
+
     def get_document_templates(self, **kwargs):
         """GET a list of Document Templates."""
         url = Session.__make_url("document_templates")

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -182,3 +182,10 @@ class TestSession(unittest.TestCase):
         self.session._Session__get_resource.assert_called_with(
             "https://app.clio.com/api/v4/documents/1/download.json"
         )
+
+    def test_delete_webhook(self):
+        self.session._Session__delete_resource = MagicMock()
+        _ = self.session.delete_webhook(1)
+        self.session._Session__delete_resource.assert_called_with(
+            "https://app.clio.com/api/v4/webhooks/1"
+        )

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -187,5 +187,5 @@ class TestSession(unittest.TestCase):
         self.session._Session__delete_resource = MagicMock()
         _ = self.session.delete_webhook(1)
         self.session._Session__delete_resource.assert_called_with(
-            "https://app.clio.com/api/v4/webhooks/1"
+            "https://app.clio.com/api/v4/webhooks/1.json"
         )


### PR DESCRIPTION
Adds `delete_webhook` functionality. Calls an HTTP `DELETE` on the provided webhook resource ID.