### PR TITLE
L-1384: POSTing new webhook should return expires_at by default

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -443,7 +443,7 @@ class Session:
                     "expires_at": expires_at,
                 },
             },
-            params={"fields": "id,shared_secret,status"},
+            params={"fields": "id,shared_secret,status,expires_at"},
         )
 
     def update_webhook(self, id, json, **kwargs):


### PR DESCRIPTION
Small PR to return expires_at for new webhook POST requests.