### PR TITLE
L-1404: Hyacinth should support unlimited cursor pagination

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -103,7 +103,7 @@ class Session:
         if not params:
             params = {}
         params["order"] = "id(asc)"
-        return self.session.get(url, **kwargs)
+        return self.session.get(url, params=params, **kwargs)
 
     @ratelimit
     def __post_resource(self, url, json, **kwargs):

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -97,7 +97,7 @@ class Session:
             )
 
     @ratelimit
-    def __get_resource(self, url, params, **kwargs):
+    def __get_resource(self, url, params=None, **kwargs):
         # use unlimited cursor pagination
         # https://docs.developers.clio.com/api-docs/paging/#unlimited-cursor-pagination
         if not params:

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -97,7 +97,12 @@ class Session:
             )
 
     @ratelimit
-    def __get_resource(self, url, **kwargs):
+    def __get_resource(self, url, params, **kwargs):
+        # use unlimited cursor pagination
+        # https://docs.developers.clio.com/api-docs/paging/#unlimited-cursor-pagination
+        if not params:
+            params = {}
+        params["order"] = "id(asc)"
         return self.session.get(url, **kwargs)
 
     @ratelimit

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -28,7 +28,7 @@ class TestSession(unittest.TestCase):
         m = MagicMock()
         self.session.session.get = m
         self.session._Session__get_resource(self.test_url)
-        m.assert_called_once_with(self.test_url)
+        m.assert_called_once_with(self.test_url, params={"order": "id(asc)"})
 
     def test__Session__get_paginated_resource_requests_correct_url(self):
         test_data = [


### PR DESCRIPTION
Adds support for [Unlimited Cursor Pagination](https://docs.developers.clio.com/api-docs/paging/#unlimited-cursor-pagination), which allows us to continuously page for results beyond 10,000 records.