### PR TITLE
L-1534: Add get_folders_content to hyacinth

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -251,12 +251,12 @@ class Session:
         return self.__get_paginated_resource(url, **kwargs)
 
     def get_folder(self, id, **kwargs):
-        """GET a Document."""
+        """GET a Folder with provided ID."""
         url = Session.__make_url(f"folders/{id}")
         return self.__get_resource(url, **kwargs)
 
     def get_folders(self, **kwargs):
-        """GET a Document."""
+        """GET a list of Folders."""
         url = Session.__make_url("folders")
         return self.__get_paginated_resource(url, **kwargs)
 

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -260,6 +260,11 @@ class Session:
         url = Session.__make_url("folders")
         return self.__get_paginated_resource(url, **kwargs)
 
+    def get_folders_content(self, **kwargs):
+        """GET a list of Folder contents."""
+        url = Session.__make_url("folders/list")
+        return self.__get_paginated_resource(url, **kwargs)
+
     def post_folder(self, name, parent_id, parent_type, **kwargs):
         """POST a new Folder."""
         url = Session.__make_url("folders")


### PR DESCRIPTION
Adds `get_folders_content()` fn to [retrieve the content of a Folder](https://docs.developers.clio.com/api-reference/#tag/Folders/operation/Folder#list).