### PR TITLE
L-1544: Add support for specifying document_category for document upload

### DIFF
--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -129,7 +129,7 @@ class AsyncSession:
         return await self.__get(url)
 
     async def upload_document(
-        self, name, parent_id, parent_type, document, params=None, **kwargs
+            self, name, parent_id, parent_type, document_category_id, document, params=None, **kwargs
     ):
         """Upload a new Document to Clio.
 
@@ -144,7 +144,11 @@ class AsyncSession:
             post_url,
             params={"fields": "id,latest_document_version{uuid,put_url,put_headers}"},
             json={
-                "data": {"name": name, "parent": {"id": parent_id, "type": parent_type}}
+                "data": {
+                    "name": name,
+                    "parent": {"id": parent_id, "type": parent_type},
+                    "document_category": {"id": document_category_id},
+                }
             },
         )
 

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -315,7 +315,7 @@ class Session:
         return self.__delete_resource(url, **kwargs)
 
     def upload_document(
-        self, name, parent_id, parent_type, document, progress_update=lambda *args: None
+            self, name, parent_id, parent_type, document_category_id, document, progress_update=lambda *args: None
     ):
         """POST a new Document, PUT the data, and PATCH Document as fully_uploaded."""
         with open(document, "rb") as f:
@@ -329,6 +329,7 @@ class Session:
                     "data": {
                         "name": name,
                         "parent": {"id": parent_id, "type": parent_type},
+                        "document_category": {"id": document_category_id},
                     }
                 },
             )
@@ -362,7 +363,7 @@ class Session:
             return patch_resp
 
     async def upload_document_async(
-        self, name, parent_id, parent_type, document, progress_update=lambda *args: None
+            self, name, parent_id, parent_type, document_category_id, document, progress_update=lambda *args: None
     ):
         """POST a new Document, PUT the data, and PATCH Document as fully_uploaded."""
         with open(document, "rb") as f:
@@ -376,6 +377,7 @@ class Session:
                     "data": {
                         "name": name,
                         "parent": {"id": parent_id, "type": parent_type},
+                        "document_category": {"id": document_category_id},
                     }
                 },
             )


### PR DESCRIPTION
Adds new args to `Session.upload_document`, `Session.upload_document_async`, and `AsyncSession.upload_document` for `document_category_id`.