### PR TITLE
L-1657: Alter hyacinth to optionally not follow pagination

### DIFF
--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -159,13 +159,12 @@ class Session:
 
     def get_paginated_resource(self, url, **kwargs):
         """GET a paginated Resource from Clio API."""
-        import ipdb; ipdb.set_trace()
         resp = self.get_resource(url, **kwargs)
         if not self.autopaginate:
-            return resp
+            yield resp
 
-        for datum in resp["data"]:
-            yield datum
+        for d in resp["data"]:
+            yield d
 
         paging = resp["meta"].get("paging")
         if paging:
@@ -178,7 +177,7 @@ class Session:
             next_url = None
 
         while next_url:
-            return self.get_paginated_resource(next_url, **kwargs)
+            yield from self.get_paginated_resource(next_url, **kwargs)
 
     def get_calendars(self, **kwargs):
         """GET Calendars."""

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -119,6 +119,7 @@ class Session:
         self.raise_for_status = raise_for_status
 
     def make_url(self, path):
+        """Make a new URL for Clio API."""
         return f"{self.api_base_url}/{path}.json"
 
     def update_ratelimits(self, response):
@@ -130,7 +131,8 @@ class Session:
             )
 
     @ratelimit
-    def __get_resource(self, url, params=None, **kwargs):
+    def get_resource(self, url, params=None, **kwargs):
+        """GET a Resource from Clio API."""
         # use unlimited cursor pagination
         # https://docs.developers.clio.com/api-docs/paging/#unlimited-cursor-pagination
         if not params:
@@ -139,21 +141,25 @@ class Session:
         return self.session.get(url, params=params, **kwargs)
 
     @ratelimit
-    def __post_resource(self, url, json, **kwargs):
+    def post_resource(self, url, json, **kwargs):
+        """POST a Resource to Clio API."""
         return self.session.post(url, json=json, **kwargs)
 
     @ratelimit
-    def __patch_resource(self, url, json, **kwargs):
+    def patch_resource(self, url, json, **kwargs):
+        """PATCH a Resource on Clio API."""
         return self.session.patch(url, json=json, **kwargs)
 
     @ratelimit
-    def __delete_resource(self, url, **kwargs):
+    def delete_resource(self, url, **kwargs):
+        """DELETE a Resource on Clio API."""
         return self.session.delete(url, **kwargs)
 
-    def __get_paginated_resource(self, url, **kwargs):
+    def get_paginated_resource(self, url, **kwargs):
+        """GET a paginated Resource from Clio API."""
         next_url = url
         while next_url:
-            resp = self.__get_resource(next_url, **kwargs)
+            resp = self.get_resource(next_url, **kwargs)
             for datum in resp["data"]:
                 yield datum
 
@@ -171,147 +177,147 @@ class Session:
     def get_calendars(self, **kwargs):
         """GET Calendars."""
         url = self.make_url("calendars")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def post_calendar_entry(self, json, **kwargs):
         """POST a Calendar Entry."""
         url = self.make_url("calendar_entries")
-        return self.__post_resource(url, json, **kwargs)
+        return self.post_resource(url, json, **kwargs)
 
     def patch_calendar_entry(self, id, json, **kwargs):
         """PATCH a Calendar Entry."""
         url = self.make_url(f"calendar_entries/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def get_calendar_entries(self, **kwargs):
         """GET a list of Calendar Entries."""
         url = self.make_url("calendar_entries")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_calendar_entry(self, calendar_entry_id, **kwargs):
         """GET a Calendar Entry with provided ID."""
         url = self.make_url(f"calendar_entries/{calendar_entry_id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_contact(self, id, **kwargs):
         """GET a Contact with provided ID."""
         url = self.make_url(f"contacts/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_contacts(self, **kwargs):
         """GET a list of Contacts."""
         url = self.make_url("contacts")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def post_contact(self, json, **kwargs):
         """POST a new Contact."""
         url = Session.make_url("contacts")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def patch_contact(self, id, json, **kwargs):
         """PATCH an existing Contact with provided ID."""
         url = Session.make_url(f"contacts/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def delete_contact(self, id, **kwargs):
         """DELETE an existing Contact with provided ID."""
         url = Session.make_url(f"contacts/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def get_custom_fields(self, **kwargs):
         """GET a list of Cusom Fields."""
         url = self.make_url("custom_fields")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_who_am_i(self, **kwargs):
         """GET currently authenticated User."""
         url = self.make_url("users/who_am_i")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_user(self, id, **kwargs):
         """GET a single Userwith provided ID."""
         url = self.make_url(f"users/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_users(self, **kwargs):
         """GET a list of Users."""
         url = self.make_url("users")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_document(self, id, **kwargs):
         """GET a Document with provided ID."""
         url = self.make_url(f"documents/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_documents(self, **kwargs):
         """GET a list of Documents."""
         url = self.make_url("documents")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def download_document(self, id, **kwargs):
         """Download a Document with provided ID."""
         url = self.make_url(f"documents/{id}/download")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def delete_document(self, id, **kwargs):
         """DELETE an existing Document with provided ID."""
         url = self.make_url(f"documents/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def patch_documentcategory(self, id, json, **kwargs):
         """PATCH an existing Document Category."""
         url = self.make_url(f"document_categories/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def patch_document(self, id, json, **kwargs):
         """PATCH an existing document with provided ID."""
         url = self.make_url(f"documents/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def get_matter(self, id, **kwargs):
         """GET a Matter with provided ID."""
         url = self.make_url(f"matters/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def patch_matter(self, id, json, **kwargs):
         """PATCH a Matter with provided ID with provided JSON."""
         url = self.make_url(f"matters/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def post_note(self, json, **kwargs):
         """POST a new Note."""
         url = self.make_url("notes")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def post_task(self, json, **kwargs):
         """POST a new Task."""
         url = self.make_url("tasks")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def get_matters(self, **kwargs):
         """GET a list of Matters."""
         url = self.make_url("matters")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_folder(self, id, **kwargs):
         """GET a Folder with provided ID."""
         url = self.make_url(f"folders/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_folders(self, **kwargs):
         """GET a list of Folders."""
         url = self.make_url("folders")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_folders_content(self, **kwargs):
         """GET a list of Folder contents."""
         url = self.make_url("folders/list")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def post_folder(self, name, parent_id, parent_type, **kwargs):
         """POST a new Folder."""
         url = self.make_url("folders")
-        return self.__post_resource(
+        return self.post_resource(
             url,
             json={
                 "data": {"name": name, "parent": {"id": parent_id, "type": parent_type}}
@@ -322,7 +328,7 @@ class Session:
     def delete_folder(self, id, **kwargs):
         """DELETE an existing Folder with provided ID."""
         url = self.make_url(f"folders/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def upload_document(
             self, name, parent_id, parent_type, document, document_category_id=None, progress_update=lambda *args: None
@@ -330,7 +336,7 @@ class Session:
         """POST a new Document, PUT the data, and PATCH Document as fully_uploaded."""
         with open(document, "rb") as f:
             post_url = self.make_url("documents")
-            clio_document = self.__post_resource(
+            clio_document = self.post_resource(
                 post_url,
                 params={
                     "fields": "id,latest_document_version{uuid,put_url,put_headers}"
@@ -357,7 +363,7 @@ class Session:
             requests.put(put_url, headers=headers_map, data=f, timeout=600)
 
             patch_url = self.make_url(f"documents/{clio_document['data']['id']}")
-            patch_resp = self.__patch_resource(
+            patch_resp = self.patch_resource(
                 patch_url,
                 params={"fields": "id,name,latest_document_version{fully_uploaded}"},
                 json={
@@ -378,7 +384,7 @@ class Session:
         """POST a new Document, PUT the data, and PATCH Document as fully_uploaded."""
         with open(document, "rb") as f:
             post_url = self.make_url("documents")
-            clio_document = self.__post_resource(
+            clio_document = self.post_resource(
                 post_url,
                 params={
                     "fields": "id,latest_document_version{uuid,put_url,put_headers}"
@@ -410,7 +416,7 @@ class Session:
                 progress_update()
 
             patch_url = self.make_url(f"documents/{clio_document['data']['id']}")
-            patch_resp = self.__patch_resource(
+            patch_resp = self.patch_resource(
                 patch_url,
                 params={"fields": "id,name,latest_document_version{fully_uploaded}"},
                 json={
@@ -453,7 +459,7 @@ class Session:
 
         post_url = self.make_url("documents")
 
-        clio_document = self.__post_resource(
+        clio_document = self.post_resource(
             post_url,
             params={
                 "fields": "id,latest_document_version{uuid,put_headers,multiparts}"
@@ -485,7 +491,7 @@ class Session:
                 progress_update()
 
         patch_url = self.make_url(f"documents/{clio_document['data']['id']}")
-        patch_resp = self.__patch_resource(
+        patch_resp = self.patch_resource(
             patch_url,
             params={"fields": "id,name,latest_document_version{fully_uploaded}"},
             json={
@@ -503,7 +509,7 @@ class Session:
         model_fields = "id"
         if fields:
             model_fields += "," + fields
-        return self.__post_resource(
+        return self.post_resource(
             post_url,
             json={
                 "data": {
@@ -520,132 +526,132 @@ class Session:
     def update_webhook(self, id, json, **kwargs):
         """PATCH an existing Webhook with provided ID."""
         url = self.make_url(f"webhooks/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def delete_webhook(self, id, **kwargs):
         """DELETE an existing Webhook with provided ID."""
         url = self.make_url(f"webhooks/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def get_webhook(self, id, **kwargs):
         """GET a single Webhook with provided ID."""
         url = self.make_url(f"webhooks/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_webhooks(self, **kwargs):
         """GET a list of all webhooks from Clio."""
         url = self.make_url("webhooks")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_document_templates(self, **kwargs):
         """GET a list of Document Templates."""
         url = self.make_url("document_templates")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def post_document_automation(self, json, **kwargs):
         """POST a new Document Automation."""
         url = self.make_url("document_automations")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def post_matter(self, json, **kwargs):
         """POST a new Matter."""
         url = self.make_url("matters")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def get_activity(self, id, **kwargs):
         """GET a single Activity with provided ID."""
         url = self.make_url(f"activities/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_activities(self, **kwargs):
         """GET a list of Activities."""
         url = self.make_url("activities")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def post_activity(self, json, **kwargs):
         """POST a new Activity."""
         url = self.make_url("activities")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def patch_activity(self, id, json, **kwargs):
         """PATCH an existing Activity with provided ID."""
         url = self.make_url(f"activities/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def delete_activity(self, id, **kwargs):
         """DELETE an existing Activity with provided ID."""
         url = self.make_url(f"activities/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def get_activity_description(self, id, **kwargs):
         """GET a single Activity Description with provided ID."""
         url = self.make_url(f"activity_descriptions/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def get_activity_descriptions(self, **kwargs):
         """GET a list of Activity Descriptions."""
         url = self.make_url("activity_descriptions")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def post_activity_description(self, json, **kwargs):
         """POST a new Activity Description."""
         url = self.make_url("activity_descriptions")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def get_bills(self, **kwargs):
         """GET a list of Bills."""
         url = self.make_url("bills")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_bill(self, id, **kwargs):
         """GET a single Bill with provided ID."""
         url = self.make_url(f"bills/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def patch_bill(self, id, json, **kwargs):
         """PATCH an existing Bill with provided ID."""
         url = self.make_url(f"bills/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def delete_bill(self, id, **kwargs):
         """DELETE an existing Bill with provided ID."""
         url = self.make_url(f"bills/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def get_line_items(self, **kwargs):
         """GET a list of Line Items."""
         url = self.make_url("line_items")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def patch_line_item(self, id, json, **kwargs):
         """PATCH an existing line item with provided ID of line item."""
         url = self.make_url(f"line_items/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def get_custom_actions(self, **kwargs):
         """GET a list of Custom Actions."""
         url = self.make_url("custom_actions")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_custom_action(self, id, **kwargs):
         """GET a single Custom Action with provided ID."""
         url = self.make_url(f"custom_actions/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def post_custom_action(self, json, **kwargs):
         """POST a new Custom Action."""
         url = self.make_url("custom_actions")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def patch_custom_action(self, id, json, **kwargs):
         """PATCH an existing Custom Action with provided ID."""
         url = self.make_url(f"custom_actions/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def delete_custom_action(self, id, **kwargs):
         """DELETE an existing Custom Action with provided ID."""
         url = self.make_url(f"custom_actions/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def verify_custom_action(self, subject_url, custom_action_nonce, **kwargs):
         """Verify a Custom Action."""
@@ -653,7 +659,7 @@ class Session:
         params = kwargs.get("params", {})
         params.update({"custom_action_nonce": custom_action_nonce})
         kwargs["params"] = params
-        return self.__get_resource(
+        return self.get_resource(
             url,
             **kwargs,
         )
@@ -661,29 +667,29 @@ class Session:
     def get_relationships(self, **kwargs):
         """GET a list of Relationships."""
         url = self.make_url("relationships")
-        return self.__get_paginated_resource(url, **kwargs)
+        return self.get_paginated_resource(url, **kwargs)
 
     def get_relationship(self, id, **kwargs):
         """GET a single Relationship with provided ID."""
         url = self.make_url(f"relationships/{id}")
-        return self.__get_resource(url, **kwargs)
+        return self.get_resource(url, **kwargs)
 
     def post_relationship(self, json, **kwargs):
         """POST a new Relationship."""
         url = self.make_url("relationships")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)
 
     def patch_relationship(self, id, json, **kwargs):
         """PATCH an existing Relationship with provided ID."""
         url = self.make_url(f"relationships/{id}")
-        return self.__patch_resource(url, json=json, **kwargs)
+        return self.patch_resource(url, json=json, **kwargs)
 
     def delete_relationship(self, id, **kwargs):
         """DELETE an existing Relationship with provided ID."""
         url = self.make_url(f"relationships/{id}")
-        return self.__delete_resource(url, **kwargs)
+        return self.delete_resource(url, **kwargs)
 
     def post_document_category(self, json, **kwargs):
         """POST a new Document Category."""
         url = self.make_url("document_categories")
-        return self.__post_resource(url, json=json, **kwargs)
+        return self.post_resource(url, json=json, **kwargs)

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -158,10 +158,15 @@ class Session:
         return self.session.delete(url, **kwargs)
 
     def get_paginated_resource(self, url, **kwargs):
-        """GET a paginated Resource from Clio API."""
-        resp = self.get_resource(url, **kwargs)
+        """Get a paginated Resource from Clio API."""
         if not self.autopaginate:
-            yield resp
+            return self.get_resource(url, **kwargs)
+        else:
+            return self.get_autopaginated_resource(url, **kwargs)
+
+    def get_autopaginated_resource(self, url, **kwargs):
+        """GET a paginated Resource from Clio API, following page links."""
+        resp = self.get_resource(url, **kwargs)
 
         for d in resp["data"]:
             yield d

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -159,6 +159,7 @@ class Session:
 
     def get_paginated_resource(self, url, **kwargs):
         """GET a paginated Resource from Clio API."""
+        import ipdb; ipdb.set_trace()
         resp = self.get_resource(url, **kwargs)
         if not self.autopaginate:
             return resp

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -80,177 +80,177 @@ class TestSession(unittest.TestCase):
     def test_get_resource_requests_correct_url(self):
         m = MagicMock()
         self.session.session.get = m
-        self.session._Session__get_resource(self.test_url)
+        self.session.get_resource(self.test_url)
         m.assert_called_once_with(self.test_url, params={"order": "id(asc)"})
 
-    def test__Session__get_paginated_resource_requests_correct_url(self):
+    def test_get_paginated_resource_requests_correct_url(self):
         test_data = [
             {"id": "1", "name": "Anson MacKeracher"},
             {"id": "2", "name": "Nick Francis"},
         ]
-        self.session._Session__get_resource = MagicMock(
+        self.session.get_resource = MagicMock(
             return_value={"data": test_data, "meta": {}}
         )
-        res = self.session._Session__get_paginated_resource(self.test_url)
+        res = self.session.get_paginated_resource(self.test_url)
         self.assertEqual(tuple(test_data), tuple(res))
 
     def test_get_contact_url(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         c = self.session.get_contact(1)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/contacts/1.json"
         )
 
     def test_get_contact_fields(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         test_fields = "id,name,email"
         u = self.session.get_contact(1, fields=test_fields)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/contacts/1.json", fields=test_fields
         )
 
     def test_get_contacts_url(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         c = self.session.get_contacts()
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/contacts.json"
         )
 
     def test_get_contacts_fields(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         test_fields = "id,name,email"
         u = self.session.get_contacts(fields=test_fields)
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/contacts.json", fields=test_fields
         )
 
     def test_get_who_am_i_url(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         u = self.session.get_who_am_i()
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/users/who_am_i.json"
         )
 
     def test_get_who_am_i_fields(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         test_fields = "id,name,email,subscription_type,enabled"
         u = self.session.get_who_am_i(fields=test_fields)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/users/who_am_i.json", fields=test_fields
         )
 
     def test_get_user_url(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         u = self.session.get_user(1)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/users/1.json"
         )
 
     def test_get_user_fields(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         test_fields = "id,name,email,subscription_type,enabled"
         u = self.session.get_user(1, fields=test_fields)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/users/1.json", fields=test_fields
         )
 
     def test_get_users_url(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         c = self.session.get_users()
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/users.json"
         )
 
     def test_get_users_fields(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         test_fields = "id,name,email,subscription_type,enabled"
         u = self.session.get_users(fields=test_fields)
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/users.json", fields=test_fields
         )
 
     def test_document_url(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         u = self.session.get_document(1)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/documents/1.json"
         )
 
     def test_document_fields(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         test_fields = "id,name,content_type"
         u = self.session.get_document(1, fields=test_fields)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/documents/1.json", fields=test_fields
         )
 
     def test_get_documents_url(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         c = self.session.get_documents()
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/documents.json"
         )
 
     def test_get_documents_fields(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         test_fields = "id,name,content_type"
         u = self.session.get_documents(fields=test_fields)
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/documents.json", fields=test_fields
         )
 
     def test_matter_url(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         u = self.session.get_matter(1)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/matters/1.json"
         )
 
     def test_matter_fields(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         test_fields = "id,client{id,first_name,last_name}"
         u = self.session.get_matter(1, fields=test_fields)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/matters/1.json", fields=test_fields
         )
 
     def test_get_matters_url(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         c = self.session.get_matters()
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/matters.json"
         )
 
     def test_get_matters_fields(self):
-        self.session._Session__get_paginated_resource = MagicMock()
+        self.session.get_paginated_resource = MagicMock()
         test_fields = "id,client{id,first_name,last_name},"
         u = self.session.get_matters(fields=test_fields)
-        self.session._Session__get_paginated_resource.assert_called_with(
+        self.session.get_paginated_resource.assert_called_with(
             "https://app.clio.com/api/v4/matters.json", fields=test_fields
         )
 
     def test_download_document(self):
-        self.session._Session__get_resource = MagicMock()
+        self.session.get_resource = MagicMock()
         u = self.session.download_document(1)
-        self.session._Session__get_resource.assert_called_with(
+        self.session.get_resource.assert_called_with(
             "https://app.clio.com/api/v4/documents/1/download.json"
         )
 
     def test_delete_webhook(self):
-        self.session._Session__delete_resource = MagicMock()
+        self.session.delete_resource = MagicMock()
         _ = self.session.delete_webhook(1)
-        self.session._Session__delete_resource.assert_called_with(
+        self.session.delete_resource.assert_called_with(
             "https://app.clio.com/api/v4/webhooks/1.json"
         )
 
     def test_update_webhook(self):
-        self.session._Session__patch_resource = MagicMock()
+        self.session.patch_resource = MagicMock()
         json = {
             "data": {
                 "fields": "id,client{id,first_name,last_name},",
             }
         }
         _ = self.session.update_webhook(1, json=json)
-        self.session._Session__patch_resource.assert_called_with(
+        self.session.patch_resource.assert_called_with(
             "https://app.clio.com/api/v4/webhooks/1.json", json=json
         )


### PR DESCRIPTION
Alter how `get_paginated_resource` works to enable workflows that don't require automatic pagination.

- Adds new option to Hyacinth session: `autopaginate` (defaults to `True` for backwards compatibility)
- Make public functions out of `__get_resource`, `__get_paginated_resource`, `__post_resource`, `__patch_resource`, `__delete_resource`
- It `autopaginate` is `False`, any paginated resources will yield **one** _**whole page**_ of resources. The assumption is that you can manually follow the next page link.