### PR TITLE
L-3081: Add POST trust requests

### DIFF
--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -294,3 +294,8 @@ class AsyncSession:
         """DELETE an existing Contact with provided ID."""
         url = self.make_url(f"contacts/{id}")
         return await self.delete_resource(url, **kwargs)
+
+    async def post_trust_request(self, json, **kwargs):
+        """POST a new Trust Request."""
+        url = self.make_url("trust_requests")
+        return await self.post_resource(url, json=json, **kwargs)

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -742,6 +742,11 @@ class Session:
         url = self.make_url(f"line_items/{id}")
         return self.patch_resource(url, json=json, **kwargs)
 
+    def post_trust_request(self, json, **kwargs):
+        """POST a new Trust Request."""
+        url = self.make_url("trust_requests")
+        return self.post_resource(url, json=json, **kwargs)
+
     def get_custom_actions(self, **kwargs):
         """GET a list of Custom Actions."""
         url = self.make_url("custom_actions")


### PR DESCRIPTION
# L-3081: Add POST trust requests
## Changes
* Adding `POST` to the `trust_requests` endpoint in both the synchronous and asynchronous clients