### PR TITLE
L-3230: Handle redirects from Clio to S3 in async client

### DIFF
--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -95,7 +95,7 @@ def ratelimit(f):
         if "application/json" in resp.headers.get("Content-Type"):
             return resp.json()
         else:
-            return resp.content()
+            return resp.content
 
     return wrapper
 

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -169,7 +169,7 @@ class AsyncSession:
 
         # Debug headers being sent
 
-        print("Request headers:", self.session._client.headers)
+        print("Request headers:", self.session.headers)
 
         resp = await self.session.get(url, params=params, **kwargs)
         print("Response headers:", resp.headers)

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -54,7 +54,7 @@ def ratelimit(f):
             s3_url = resp.headers["location"]
             if "s3." in s3_url:
                 # Use raw session without auth for S3 presigned URLs
-                resp = await self.session._client.get(s3_url)
+                resp = await self.session.get(s3_url)
             else:
                 # Use normal authenticated request for other redirects
                 resp = await self.get_resource(s3_url)

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -167,13 +167,15 @@ class AsyncSession:
             params = {}
         params["order"] = "id(asc)"
 
-        # Debug headers being sent
+        # Debug the actual request headers
 
-        print("Request headers:", self.session.headers)
-
-        resp = await self.session.get(url, params=params, **kwargs)
-        print("Response headers:", resp.headers)
-        return resp
+        headers = kwargs.get("headers", {})
+        print("Request headers before:", headers)
+        response = await self.session.get(url, params=params, **kwargs)
+        print(
+            "Final request headers:", response.request.headers
+        )  # See what was actually sent
+        return response
 
     @ratelimit
     async def post_resource(self, url, json, **kwargs):

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -6,6 +6,7 @@ import asyncio
 import aiohttp
 import aiofiles
 import aiofiles.os
+import httpx
 import base64
 import math
 
@@ -53,10 +54,10 @@ def ratelimit(f):
         if resp.is_redirect and "location" in resp.headers:
             s3_url = resp.headers["location"]
             if "s3." in s3_url:
-                # Use raw session without auth for S3 presigned URLs
-                resp = await self.session.get(s3_url)
+                # Create a new client without auth headers for S3
+                async with httpx.AsyncClient() as client:
+                    resp = await client.get(s3_url)
             else:
-                # Use normal authenticated request for other redirects
                 resp = await self.get_resource(s3_url)
 
         # Sometimes we get a crazy json encoded rate limit error instead of the normal one

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -41,6 +41,12 @@ def ratelimit(f):
     async def wrapper(self, *args, **kwargs):
         resp = await f(self, *args, **kwargs)
 
+        # Debug response chain
+        print("Response URL:", resp.url)
+        print("Response history:", resp.history)  # Will show any redirects
+        print("Final response headers:", resp.headers)
+        print("Is redirect:", resp.is_redirect)
+
         if resp.status_code == 429 and self.ratelimit:
             retry_after = resp.headers.get(CLIO_API_RETRY_AFTER)
             log.info(f"Clio Rate Limit hit, Retry-After: {retry_after}s")

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -84,7 +84,7 @@ def ratelimit(f):
         if "application/json" in resp.headers.get("Content-Type"):
             return resp.json()
         else:
-            return resp.text()
+            return resp.content()
 
     return wrapper
 
@@ -385,7 +385,7 @@ class AsyncSession:
         """GET a Matter with provided ID."""
         url = self.make_url(f"matters/{id}")
         return await self.get_resource(url, **kwargs)
-    
+
     async def get_matters(self, **kwargs):
         """GET a list of Matters."""
         url = self.make_url("matters")
@@ -559,7 +559,7 @@ class AsyncSession:
         """POST a new Matter."""
         url = self.make_url("matters")
         return await self.post_resource(url, json=json, **kwargs)
-    
+
     async def patch_matter(self, id, json, **kwargs):
         """PATCH a Matter with provided ID with provided JSON."""
         url = self.make_url(f"matters/{id}")
@@ -589,7 +589,7 @@ class AsyncSession:
         """GET a list of Users."""
         url = self.make_url("users")
         return await self.get_paginated_resource(url, **kwargs)
-    
+
     async def post_calendar_entry(self, json, **kwargs):
         """POST a Calendar Entry."""
         url = self.make_url("calendar_entries")
@@ -634,7 +634,7 @@ class AsyncSession:
         """GET a list of Documents."""
         url = self.make_url("documents")
         return await self.get_paginated_resource(url, **kwargs)
-    
+
     async def get_matter_finances(self, id, **kwargs):
         """GET a Matter's Finances with provided ID."""
         url = self.make_url(f"matter_finances/{id}")

--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -166,7 +166,14 @@ class AsyncSession:
         if not params:
             params = {}
         params["order"] = "id(asc)"
-        return await self.session.get(url, params=params, **kwargs)
+
+        # Debug headers being sent
+
+        print("Request headers:", self.session._client.headers)
+
+        resp = await self.session.get(url, params=params, **kwargs)
+        print("Response headers:", resp.headers)
+        return resp
 
     @ratelimit
     async def post_resource(self, url, json, **kwargs):


### PR DESCRIPTION
# L-3230: Handle redirects from Clio to S3 in async client
## Changes
* Check if the redirect URL is s3 and handle appropriately