### PR TITLE
L-3374: Full support for DocumentCategories

### DIFF
--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -796,10 +796,30 @@ class AsyncSession:
         url = self.make_url(f"relationships/{id}")
         return await self.delete_resource(url, **kwargs)
 
+    async def get_document_categories(self, **kwargs):
+        """GET a list of Document Categories."""
+        url = self.make_url("document_categories")
+        return await self.get_paginated_resource(url, **kwargs)
+
+    async def get_document_category(self, id, **kwargs):
+        """GET a single Document Category with provided ID."""
+        url = self.make_url(f"document_categories/{id}")
+        return await self.get_resource(url, **kwargs)
+
+    async def patch_document_category(self, id, json, **kwargs):
+        """PATCH an existing Document Category with provided ID."""
+        url = self.make_url(f"document_categories/{id}")
+        return await self.patch_resource(url, json=json, **kwargs)
+
     async def post_document_category(self, json, **kwargs):
         """POST a new Document Category."""
         url = self.make_url("document_categories")
         return await self.post_resource(url, json=json, **kwargs)
+
+    async def delete_document_category(self, id, **kwargs):
+        """DELETE an existing Document Category with provided ID."""
+        url = self.make_url(f"document_categories/{id}")
+        return await self.delete_resource(url, **kwargs)
 
     async def get_practice_areas(self, **kwargs):
         """GET a list of Practice Areas."""

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -291,10 +291,30 @@ class Session:
         url = self.make_url(f"documents/{id}")
         return self.delete_resource(url, **kwargs)
 
-    def patch_documentcategory(self, id, json, **kwargs):
+    def get_document_categories(self, **kwargs):
+        """GET a list of Document Categories."""
+        url = self.make_url("document_categories")
+        return self.get_paginated_resource(url, **kwargs)
+
+    def get_document_category(self, id, **kwargs):
+        """GET a single Document Category with provided ID."""
+        url = self.make_url(f"document_categories/{id}")
+        return self.get_resource(url, **kwargs)
+
+    def post_document_category(self, json, **kwargs):
+        """POST a new Document Category."""
+        url = self.make_url("document_categories")
+        return self.post_resource(url, json=json, **kwargs)
+
+    def patch_document_category(self, id, json, **kwargs):
         """PATCH an existing Document Category."""
         url = self.make_url(f"document_categories/{id}")
         return self.patch_resource(url, json=json, **kwargs)
+
+    def delete_document_category(self, id, **kwargs):
+        """DELETE an existing Document Category."""
+        url = self.make_url(f"document_categories/{id}")
+        return self.delete_resource(url, **kwargs)
 
     def patch_document(self, id, json, **kwargs):
         """PATCH an existing document with provided ID."""


### PR DESCRIPTION
# L-3374: Full support for DocumentCategories
## Changes
This pull request introduces new methods to handle document categories in both asynchronous and synchronous sessions. The changes include adding methods to get, post, patch, and delete document categories.

### Asynchronous session changes:
* [`hyacinth/async_session.py`](diffhunk://#diff-bf70adb2d1202972e037610d4b00d7b943ac257db1dab8dde364c8198dabb7d6R799-R823): Added methods `get_document_categories`, `get_document_category`, `patch_document_category`, and `delete_document_category` to handle document categories.

### Synchronous session changes:
* [`hyacinth/session.py`](diffhunk://#diff-053453a468dda5756e7c5fe302404cfed3adbcdfc96dd28f67bf88aafb295b80L294-R318): Added methods `get_document_categories`, `get_document_category`, `post_document_category`, `patch_document_category`, and `delete_document_category` to handle document categories.