### PR TITLE
L-3375: Support including DocumentCategories when POSTing folders

### DIFF
--- a/hyacinth/async_session.py
+++ b/hyacinth/async_session.py
@@ -426,13 +426,19 @@ class AsyncSession:
         url = self.make_url("folders/list")
         return await self.get_paginated_resource(url, **kwargs)
 
-    async def post_folder(self, name, parent_id, parent_type, **kwargs):
+    async def post_folder(
+        self, name, parent_id, parent_type, document_category_id=None, **kwargs
+    ):
         """POST a new Folder."""
         url = self.make_url("folders")
         return await self.post_resource(
             url,
             json={
-                "data": {"name": name, "parent": {"id": parent_id, "type": parent_type}}
+                "data": {
+                    "name": name,
+                    "parent": {"id": parent_id, "type": parent_type},
+                    "document_category": {"id": document_category_id},
+                }
             },
             **kwargs,
         )

--- a/hyacinth/session.py
+++ b/hyacinth/session.py
@@ -406,13 +406,19 @@ class Session:
         url = self.make_url("folders/list")
         return self.get_paginated_resource(url, **kwargs)
 
-    def post_folder(self, name, parent_id, parent_type, **kwargs):
+    def post_folder(
+        self, name, parent_id, parent_type, document_category_id=None, **kwargs
+    ):
         """POST a new Folder."""
         url = self.make_url("folders")
         return self.post_resource(
             url,
             json={
-                "data": {"name": name, "parent": {"id": parent_id, "type": parent_type}}
+                "data": {
+                    "name": name,
+                    "parent": {"id": parent_id, "type": parent_type},
+                    "document_category": {"id": document_category_id},
+                }
             },
             **kwargs,
         )


### PR DESCRIPTION
# L-3375: Support including DocumentCategories when POSTing folders
## Changes
This pull request includes changes to the `post_folder` method in both the `hyacinth/async_session.py` and `hyacinth/session.py` files. The changes add an optional `document_category_id` parameter to the method, allowing the inclusion of a document category when creating a new folder.

Changes to `post_folder` method:

* [`hyacinth/async_session.py`](diffhunk://#diff-bf70adb2d1202972e037610d4b00d7b943ac257db1dab8dde364c8198dabb7d6L429-R441): Added an optional `document_category_id` parameter to the `post_folder` method and included it in the JSON payload if provided.
* [`hyacinth/session.py`](diffhunk://#diff-053453a468dda5756e7c5fe302404cfed3adbcdfc96dd28f67bf88aafb295b80L409-R421): Added an optional `document_category_id` parameter to the `post_folder` method and included it in the JSON payload if provided.